### PR TITLE
Search VM Integration Service by CLR Type Name

### DIFF
--- a/New-VMFromWindowsImage.ps1
+++ b/New-VMFromWindowsImage.ps1
@@ -54,7 +54,8 @@ Convert-WindowsImage -SourcePath $SourcePath -Edition $Edition -VHDPath $vhdxPat
 Write-Verbose 'Creating VM...'
 $vm = New-VM -Name $VMName -Generation 2 -MemoryStartupBytes $MemoryStartupBytes -VHDPath $vhdxPath -SwitchName $VMSwitchName
 $vm | Set-VMProcessor -Count $VMProcessorCount
-$vm | Get-VMIntegrationService -Name "Guest Service Interface" | Enable-VMIntegrationService -Passthru
+$gsiName = (Get-VMIntegrationService -VMName $VMName | Where-Object { $_.GetType() -eq [Microsoft.HyperV.PowerShell.GuestServiceInterfaceComponent] }).Name
+$vm | Get-VMIntegrationService -Name "$gsiName" | Enable-VMIntegrationService -Passthru
 $vm | Set-VMMemory -DynamicMemoryEnabled:$EnableDynamicMemory.IsPresent
 
 if ($VMMacAddress) {


### PR DESCRIPTION
In a localized OS, 'Guest Service Interface' is not exists. Instead, search the GSI with a CLR type name.
Similar Issue: https://github.com/dsccommunity/xHyper-V/issues/76